### PR TITLE
fix: switch multipart default mode to RFC6532 and drop setCharset (SRE-580487)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.mashape.unirest</groupId>
 	<artifactId>unirest-java</artifactId>
 	<packaging>jar</packaging>
-	<version>1.4.10-CE-0.3</version>
+	<version>1.4.10-CE-0.4</version>
 	<name>unirest-java</name>
 	<description>Simplified, lightweight HTTP client library</description>
 	<url>http://unirest.io/</url>

--- a/src/main/java/com/mashape/unirest/request/body/MultipartBody.java
+++ b/src/main/java/com/mashape/unirest/request/body/MultipartBody.java
@@ -152,9 +152,15 @@ public class MultipartBody extends BaseRequest implements Body {
 			if (mode != null) {
 				builder.setMode(mode);
 			} else {
-				builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
+				// RFC6532 hard-codes UTF-8 for part-header bytes, which preserves
+				// non-ASCII filenames (e.g. Japanese) per RFC 5987 / 6266.
+				// Do NOT call builder.setCharset(...) — in any mode it appends an
+				// illegal `charset=` parameter to the outer
+				// `Content-Type: multipart/form-data` header, which RFC 7578 §4.6
+				// forbids and strict parsers (ServiceNow, older Tomcat) reject
+				// with HTTP 400 "File part might be missing".
+				builder.setMode(HttpMultipartMode.RFC6532);
 			}
-			builder.setCharset(java.nio.charset.StandardCharsets.UTF_8);
 			for (String key : parameters.keySet()) {
 				List<Object> value = parameters.get(key);
 				ContentType contentType = contentTypes.get(key);

--- a/src/test/java/com/mashape/unirest/test/http/MultipartBodyTest.java
+++ b/src/test/java/com/mashape/unirest/test/http/MultipartBodyTest.java
@@ -1,0 +1,112 @@
+/*
+The MIT License
+
+Copyright (c) 2013 Mashape (http://mashape.com)
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.mashape.unirest.test.http;
+
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.request.body.MultipartBody;
+
+import org.apache.http.HttpEntity;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Wire-shape assertions on the multipart entity produced by {@link MultipartBody}.
+ * These tests do not make any HTTP call — they inspect the bytes that would be
+ * sent on the wire, so they run in CI without external dependencies and pin the
+ * exact behaviour vendors like ServiceNow and Data Fabric depend on.
+ */
+public class MultipartBodyTest {
+
+	/**
+	 * Regression guard for SRE-580487: the outer
+	 * {@code Content-Type: multipart/form-data} header must NOT carry a
+	 * {@code charset=} parameter. RFC 7578 §4.6 forbids it, and strict
+	 * parsers (e.g. ServiceNow's multipart parser) reject the request with
+	 * HTTP 400 "File part might be missing" when the parameter is present.
+	 *
+	 * Calling {@code MultipartEntityBuilder.setCharset(...)} would re-introduce
+	 * this parameter; this test pins the absence so any future re-introduction
+	 * fails CI rather than a customer.
+	 */
+	@Test
+	public void outerContentTypeHasNoCharsetParameter() {
+		MultipartBody body = Unirest.post("http://example.com/")
+				.field("name", "Mark")
+				.field(
+						"file",
+						new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)),
+						"test.txt");
+
+		HttpEntity entity = body.getEntity();
+		String contentType = entity.getContentType().getValue();
+
+		assertTrue(
+				"expected multipart/form-data, got: " + contentType,
+				contentType.startsWith("multipart/form-data"));
+		assertFalse(
+				"outer Content-Type must NOT include a charset parameter (RFC 7578 §4.6); got: " + contentType,
+				contentType.toLowerCase().contains("charset"));
+	}
+
+	/**
+	 * Regression guard for ENGCE-55462: a non-ASCII (Japanese) filename must
+	 * survive intact in the rendered multipart body bytes. Under
+	 * {@link org.apache.http.entity.mime.HttpMultipartMode#RFC6532} the part
+	 * headers are written as UTF-8 directly, so the filename appears
+	 * byte-for-byte in the entity stream.
+	 *
+	 * Without RFC6532 mode (or a UTF-8 charset on the builder) header bytes
+	 * fall back to ISO-8859-1 and Japanese characters collapse to '?'.
+	 */
+	@Test
+	public void japaneseFilenameSurvivesInRenderedBody() throws Exception {
+		String filename = "日本語.txt";
+		MultipartBody body = Unirest.post("http://example.com/")
+				.field(
+						"file",
+						new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)),
+						filename);
+
+		HttpEntity entity = body.getEntity();
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		entity.writeTo(out);
+		String rendered = new String(out.toByteArray(), StandardCharsets.UTF_8);
+
+		assertTrue(
+				"rendered multipart body must contain the literal UTF-8 filename '"
+						+ filename + "'; got bytes:\n" + rendered,
+				rendered.contains(filename));
+		assertFalse(
+				"rendered body must not contain '?'-substituted filename (ASCII fallback)",
+				rendered.contains("???.txt"));
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the ServiceNow Add Attachment regression (SRE-580487) while preserving the Japanese-filename fix from #3 (ENGCE-55462).

#3 added `builder.setCharset(StandardCharsets.UTF_8)` to fix non-ASCII filenames being collapsed to `?`. That call has two coupled effects in Apache HttpClient's `MultipartEntityBuilder`:

1. Encodes part-header bytes (the `filename=` token in `Content-Disposition`) in the chosen charset — what we wanted.
2. Appends `; charset=UTF-8` to the outer `Content-Type: multipart/form-data` header — what we did **not** want. **RFC 7578 §4.6** explicitly says `multipart/form-data` does not register a `charset` parameter, and strict parsers (ServiceNow, older Tomcat) reject it with HTTP 400 → `DAP-RT-1101: File part might be missing in the request`.

## Fix

- Switch the default `HttpMultipartMode` from `BROWSER_COMPATIBLE` to `RFC6532`. RFC6532 mode hard-codes UTF-8 for part-header bytes per **RFC 5987/6266**, so non-ASCII filenames survive without any `setCharset` call.
- Remove the `builder.setCharset(...)` call entirely — it would re-introduce the illegal outer-Content-Type `charset=` parameter regardless of mode.
- Bump fork version `1.4.10-CE-0.3` → `1.4.10-CE-0.4`.

## Wire-shape before/after

**Before (`1.4.10-CE-0.3`)**
```
Content-Type: multipart/form-data; boundary=----xyz; charset=UTF-8
                                                     ^^^^^^^^^^^^^ illegal, breaks ServiceNow
...
Content-Disposition: form-data; name="file"; filename="日本語.txt"  UTF-8 bytes
```

**After (`1.4.10-CE-0.4`, this PR)**
```
Content-Type: multipart/form-data; boundary=----xyz
                                                                   clean, RFC 7578 compliant
...
Content-Disposition: form-data; name="file"; filename="日本語.txt"  still UTF-8 bytes
```

## Regression tests added (`MultipartBodyTest`)

- `outerContentTypeHasNoCharsetParameter` — pins the absence of `charset=` on the outer multipart Content-Type. Would have caught the SRE-580487 regression in CI.
- `japaneseFilenameSurvivesInRenderedBody` — pins the UTF-8 round-trip of `日本語.txt` in the rendered multipart body bytes. Would have caught the original ENGCE-55462 bug without any live HTTP call.

Both run without an HTTP server (they call `MultipartBody.getEntity()` and inspect the resulting `HttpEntity`'s bytes directly).

Verified locally:
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

## Post-merge

1. Publish `1.4.10-CE-0.4` to the github-packages maven repo (manual step).
2. Bump unirest-java dep in udon from `1.4.10-CE-0.2-SNAPSHOT` (current after the hotfix revert) to `1.4.10-CE-0.4`.
3. Regress against the multipart connector matrix in non-prod: ServiceNow add-attachment (SRE-580487), Data Fabric Japanese filename (ENGCE-55462), SharePoint/Box/Drive/SF attachments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)